### PR TITLE
Fix autoloader path normalization for plugin classes

### DIFF
--- a/tmw-affiliate-manager.php
+++ b/tmw-affiliate-manager.php
@@ -22,7 +22,9 @@ spl_autoload_register(function ($class) {
     $len = strlen($prefix);
     if (strncmp($prefix, $class, $len) !== 0) { return; }
     $relative_class = substr($class, $len);
-    $file = $base_dir . 'class-' . strtolower(str_replace('\\', '-', $relative_class)) . '.php';
+    $relative_path = str_replace('\\', '-', $relative_class);
+    $relative_path = str_replace('_', '-', $relative_path);
+    $file = $base_dir . 'class-' . strtolower($relative_path) . '.php';
     if (is_readable($file)) { require $file; }
 });
 


### PR DESCRIPTION
## Summary
- update the plugin autoloader to translate underscores in class names to hyphenated file names
- ensure Banner_Zones and Admin_Menu classes load correctly on case-sensitive systems

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39c7b92c483248ef87a70e4a65caf