### PR TITLE
Fix: normalize plugin header encoding for WP Pusher

### DIFF
--- a/tmw-affiliate-manager.php
+++ b/tmw-affiliate-manager.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Plugin Name: TMW Affiliate Manager
- * Plugin URI: https://github.com/themilisofialtd-rgb/tmw-affiliate-manager
- * Description: Foundation build for the TMW Affiliate Manager — banner zones, cron scheduler, and logger system.
- * Version: 1.0.2
- * Author: Adultwebmaster69
- * Author URI: https://top-models.webcam
- * Text Domain: tmw-affiliate-manager
+ * Plugin Name:       TMW Affiliate Manager
+ * Plugin URI:        https://github.com/themilisofialtd-rgb/tmw-affiliate-manager
+ * Description:       Foundation build for the TMW Affiliate Manager - banner zones, cron scheduler, and logger system.
+ * Version:           1.0.2
+ * Author:            Adultwebmaster69
+ * Author URI:        https://top-models.webcam
+ * Text Domain:       tmw-affiliate-manager
  */
 
 if (!defined('ABSPATH')) { exit; }


### PR DESCRIPTION
## Summary
- normalize the plugin header block to match the standard WordPress field formatting
- ensure the description uses ASCII-safe characters to avoid encoding issues in the header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b69df184832481c45527a1f915aa